### PR TITLE
[linux] Check remaining free space for target folder instead of working directory

### DIFF
--- a/Filler.sh
+++ b/Filler.sh
@@ -18,7 +18,7 @@ i=0
 
 # Function to get free space in MB on the current filesystem
 get_free_mb() {
-    df -Pm . | awk 'NR==2 {print $4}'
+    df -Pm "$dir" | awk 'NR==2 {print $4}'
 }
 
 echo "How much free space (in MB) do you want to leave on disk?"


### PR DESCRIPTION
Previously, if you launched `Filler.sh` from outside your kindle root folder and changed the `dir` variable to indicate the kindle root, the script would check the free space of the *working directory* (i.e. where you launched the it) instead of the target directory you want to fill up.

This PR fixes that and checks the remaining space for the target folder instead, making sure you can run the script outside of the kindle root.

Note: I can't run the powershell script right now so i didn't change it, but the fix should be similar for `Filler.ps1`, getting the drive letter from `dir` instead of from the CWD