### PR TITLE
Update Filler.ps1 to leave the requested free space

### DIFF
--- a/Filler.ps1
+++ b/Filler.ps1
@@ -10,11 +10,22 @@ Write-Host "--------------------------------------------------------------------
 $dir = "fill_disk"
 if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir | Out-Null }
 $i = 0
+$maxFileSize = 1GB
 
 function Get-FreeBytes {
     $drive = (Get-Location).Path.Substring(0,2)
     $free = (Get-PSDrive -Name $drive[0]).Free
     return $free
+}
+
+function Get-PrettyFileSize($size) {
+    $suffix = "B", "KB", "MB", "GB", "TB"
+    $index = 0
+    while ($size -ge 1KB) {
+        $size = $size / 1KB
+        $index++
+    }
+    return "{0:N1} {1}" -f $size, $suffix[$index]
 }
 
 # Menu for user to select free space to leave
@@ -41,34 +52,32 @@ switch ($choice) {
     default { $minFreeMB = 20 }
 }
 
+$expectedFreeSize = $minFreeMB * 1MB
+
 Write-Host "Filling disk with files. Please wait..."
 while ($true) {
-    $freeBytes = Get-FreeBytes
-    $freeMB = [math]::Floor($freeBytes / 1MB)
-    $freeGB = [math]::Floor($freeBytes / 1GB)
-
-    if ($freeGB -ge 1) {
-        $fileSize = 1GB
-        $fileLabel = "1GB"
-    } elseif ($freeMB -ge 100) {
-        $fileSize = 100MB
-        $fileLabel = "100MB"
-    } elseif ($freeMB -ge $minFreeMB) {
-        $fileSize = 10MB
-        $fileLabel = "10MB"
-    } else {
-        break
+    $freeBytes = (Get-FreeBytes) - $expectedFreeSize
+    $fileSize = $maxFileSize
+    if ($freeBytes -lt $maxFileSize) {
+        $fileSize = $freeBytes
     }
 
-    if ($freeMB -lt $minFreeMB) { break }
+    if ($fileSize -le $expectedFreeSize) { break }
 
+    $fileLabel = Get-PrettyFileSize $fileSize
     $filePath = Join-Path $dir "file_$i"
+    Write-Host ("Creating file_$i of size $fileLabel...")
     fsutil file createnew $filePath $fileSize | Out-Null
     if (-not (Test-Path $filePath)) { break }
-    Write-Host ("Created file_$i of size $fileLabel. Remaining free space: {0} MB" -f $freeMB)
+    $freeBytes = Get-FreeBytes
+    $freeBytesLabel = Get-PrettyFileSize $freeBytes
+    Write-Host ("Created file_$i of size $fileLabel. Remaining free space: $freeBytesLabel")
     $i++
 }
 
-Write-Host "Space exhausted or less than $minFreeMB MB free after creating $i files in $dir."
+$freeBytes = Get-FreeBytes
+$freeBytesLabel = Get-PrettyFileSize $freeBytes
+
+Write-Host "Done filling up the disk. $freeBytesLabel free after creating $i files in $dir."
 Write-Host "You can now check the $dir folder. Press any key to exit."
 Pause


### PR DESCRIPTION
On my Kindle Voyage, I requested 20 MB free, but the script filled up too much space so that I had only 11 MB free. I updated the script to calculate the free space correctly and leave the exact free space as requested.